### PR TITLE
UTXO transaction fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,9 @@
 ##### Make custom gas parameter compulsory
 
 - Changed satPerByte from optional to compulsory parameter.
+
+### 1.2.2 (2022-09-06)
+
+##### UTXO calculation fix
+
+- UTXO.satoshi calculation fix.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsafle/vault-bitcoin-controller",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getsafle/vault-bitcoin-controller",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "",
   "engines": {
     "node": ">= 10"

--- a/src/helper/calculateFeeAndInput.js
+++ b/src/helper/calculateFeeAndInput.js
@@ -13,7 +13,7 @@ async function getFeeAndInput(URL, satPerByte) {
     let inputs = [];
     utxos.data.data.txs.forEach(async (element) => {
         let utxo = {};
-        utxo.satoshis = Math.floor(Number(element.value) * SATOSHI);
+        utxo.satoshis = Math.ceil(parseFloat(element.value) * SATOSHI);
         utxo.script = element.script_hex;
         utxo.address = utxos.data.data.address;
         utxo.txId = element.txid;


### PR DESCRIPTION
While calculating the UTXO of the address, we were getting the wrong input values. That is because of how JS computes the multiplication of floating point numbers. The multiplication causes the lesser value of the actual satoshi amount due to which we were getting the incorrect UTXO value error while broadcasting the transaction on the bitcoin network.
The error is resolved using `Math.ceil` in satoshi calculation